### PR TITLE
ODNU007: Configure Firebase Auth with AsyncStorage for persistent login

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,13 +4,13 @@ import NasaUpdate from '@/components/nasaUpdate/NasaUpdate';
 import Header from '@/components/header/NasaHeader';
 import { signOut } from 'firebase/auth';
 import { useRouter } from 'expo-router';
-import { FIREBASE_AUTH } from '@/firebase-config';
+import { auth } from '@/firebase-config';
 
 export default function HomeScreen() {
   const router = useRouter();
 
   const handleSignOut = async () => {
-    await signOut(FIREBASE_AUTH);
+    await signOut(auth);
     router.replace('/auth/login');
   };
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,7 @@ import { Stack } from "expo-router";
 import { useFonts } from "expo-font";
 import { useEffect, useState } from "react";
 import { onAuthStateChanged, User } from "firebase/auth";
-import { FIREBASE_AUTH } from "@/firebase-config";
+import { auth } from "@/firebase-config";
 import { View, ActivityIndicator, Text } from "react-native";
 import { useRouter } from "expo-router";
 import "react-native-reanimated";
@@ -24,7 +24,7 @@ export default function RootLayout() {
   });
 
   useEffect(() => {
-    const subscriber = onAuthStateChanged(FIREBASE_AUTH, (authUser) => {
+    const subscriber = onAuthStateChanged(auth, (authUser) => {
       setUser(authUser);
       setInitializing(false);
     });

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { SafeAreaView, View, Alert, TouchableOpacity, StyleSheet } from "react-native";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
-import { FIREBASE_AUTH } from "@/firebase-config";
+import { auth } from "@/firebase-config";
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { useRouter } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
@@ -16,7 +16,7 @@ export default function Login() {
 
   const handleLogin = async () => {
     try {
-      await signInWithEmailAndPassword(FIREBASE_AUTH, email, password);
+      await signInWithEmailAndPassword(auth, email, password);
       router.replace("/(tabs)"); 
     } catch (error: any) {
       Alert.alert("Login failed", error.message);

--- a/app/auth/register.tsx
+++ b/app/auth/register.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
-import { FIREBASE_AUTH } from "@/firebase-config";
+import { auth } from "@/firebase-config";
 import { createUserWithEmailAndPassword } from "firebase/auth";
 import { useRouter } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
@@ -22,7 +22,7 @@ export default function Register() {
 
   const handleRegister = async () => {
     try {
-      await createUserWithEmailAndPassword(FIREBASE_AUTH, email, password);
+      await createUserWithEmailAndPassword(auth, email, password);
       Alert.alert("Success", "Registration successful, please log in.");
       router.replace("/auth/login"); 
     } catch (error: any) {

--- a/components/ctx/AuthContext.tsx
+++ b/components/ctx/AuthContext.tsx
@@ -1,6 +1,6 @@
 // ctx/AuthContext.tsx
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { FIREBASE_AUTH } from '@/firebase-config';
+import { auth } from '@/firebase-config';
 import { onAuthStateChanged, User } from 'firebase/auth';
 
 interface AuthContextType {
@@ -16,7 +16,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(FIREBASE_AUTH, (user) => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
       setUser(user);
       setIsLoading(false);
     });
@@ -24,7 +24,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const signOut = async () => {
-    await FIREBASE_AUTH.signOut();
+    await auth.signOut();
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@expo/vector-icons": "^14.0.2",
     "@firebase/auth": "^1.7.9",
     "@langchain/community": "^0.3.4",
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-firebase/auth": "^21.0.0",
     "@react-navigation/native": "^6.0.2",
     "expo": "~51.0.37",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "strict": true,
     "paths": {
-      "@/*": [
-        "./*"
+      "@/*": ["./*"],
+      "@firebase/auth": ["./node_modules/@firebase/auth/dist/index.rn.d.ts"],
+      "@react-native-async-storage/async-storage": [
+        "./node_modules/@react-native-async-storage/async-storage"
       ]
     }
   },


### PR DESCRIPTION
- Set up Firebase Auth using initializeAuth with getReactNativePersistence to enable session persistence across app restarts.
- Added @react-native-async-storage/async-storage for persistence layer compatibility in React Native.
- Updated firebase-config.ts to ensure auth state is stored and retrieved from AsyncStorage.
- Adjusted RootLayout component to handle auth state changes based on persistent storage.
- Resolved potential import issues by adjusting paths and ensuring compatibility with Expo and TypeScript setup.